### PR TITLE
Enable v3_routeConfig future flag for React Router v7 migration

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -1,0 +1,3 @@
+import { flatRoutes } from "@remix-run/fs-routes";
+
+export default flatRoutes();

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "mailgun.js": "^4.1.4",
         "prisma": "^5.13.0",
         "react": "^18.2.0",
-        "react-confetti": "^6.1.0",
         "react-dom": "^18.2.0",
         "react-icons": "^4.3.1",
         "remix": "^2.16.8"
@@ -28,6 +27,8 @@
       "devDependencies": {
         "@faker-js/faker": "^7.6.0",
         "@remix-run/dev": "^2.16.8",
+        "@remix-run/fs-routes": "^2.16.8",
+        "@remix-run/route-config": "^2.16.8",
         "@types/bcrypt": "^5.0.0",
         "@types/jsonwebtoken": "^8.5.6",
         "@types/node": "^18.11.18",
@@ -1561,6 +1562,25 @@
         }
       }
     },
+    "node_modules/@remix-run/fs-routes": {
+      "version": "2.16.8",
+      "resolved": "https://registry.npmjs.org/@remix-run/fs-routes/-/fs-routes-2.16.8.tgz",
+      "integrity": "sha512-9/yD8d3s4UGI7WM17sgxfHBz7mtLFC2GRUtbcVukfIO8lpY1VNtx9Ap+CqXKTlHQcSSFpDLPEPCyF6f9xoe6yw==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@remix-run/dev": "^2.16.8",
+        "@remix-run/route-config": "^2.16.8",
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/node": {
       "version": "2.16.8",
       "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.16.8.tgz",
@@ -1603,6 +1623,27 @@
       "peerDependencies": {
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
+        "typescript": "^5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remix-run/route-config": {
+      "version": "2.16.8",
+      "resolved": "https://registry.npmjs.org/@remix-run/route-config/-/route-config-2.16.8.tgz",
+      "integrity": "sha512-YEhm2N9LIyBtGNdo6efbFCxmLHG5qdQlYyoMZdR5CaLAMICpdXr3It12xft+SoQiNL6ALnEHM9oiisZijvFZcQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "@remix-run/dev": "^2.16.8",
         "typescript": "^5.1.0"
       },
       "peerDependenciesMeta": {
@@ -7460,20 +7501,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-confetti": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.1.0.tgz",
-      "integrity": "sha512-7Ypx4vz0+g8ECVxr88W9zhcQpbeujJAVqL14ZnXJ3I23mOI9/oBVTQ3dkJhUmB0D6XOtCZEM6N0Gm9PMngkORw==",
-      "dependencies": {
-        "tween-functions": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=10.18"
-      },
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.1 || ^18.0.0"
-      }
-    },
     "node_modules/react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -8515,11 +8542,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.1.tgz",
       "integrity": "sha512-v8kOJXpG3WoTN/+at8vK7erSzo6nW6CIaeOvNOkHQVDajfz1ZVeSxCbc6tOH4hrGZW7VUCV0TOXd8CPzYnYkrw=="
-    },
-    "node_modules/tween-functions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
-      "integrity": "sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA=="
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -11083,6 +11105,13 @@
         "@remix-run/node": "2.16.8"
       }
     },
+    "@remix-run/fs-routes": {
+      "version": "2.16.8",
+      "resolved": "https://registry.npmjs.org/@remix-run/fs-routes/-/fs-routes-2.16.8.tgz",
+      "integrity": "sha512-9/yD8d3s4UGI7WM17sgxfHBz7mtLFC2GRUtbcVukfIO8lpY1VNtx9Ap+CqXKTlHQcSSFpDLPEPCyF6f9xoe6yw==",
+      "dev": true,
+      "requires": {}
+    },
     "@remix-run/node": {
       "version": "2.16.8",
       "resolved": "https://registry.npmjs.org/@remix-run/node/-/node-2.16.8.tgz",
@@ -11107,6 +11136,15 @@
         "react-router": "6.30.0",
         "react-router-dom": "6.30.0",
         "turbo-stream": "2.4.1"
+      }
+    },
+    "@remix-run/route-config": {
+      "version": "2.16.8",
+      "resolved": "https://registry.npmjs.org/@remix-run/route-config/-/route-config-2.16.8.tgz",
+      "integrity": "sha512-YEhm2N9LIyBtGNdo6efbFCxmLHG5qdQlYyoMZdR5CaLAMICpdXr3It12xft+SoQiNL6ALnEHM9oiisZijvFZcQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21"
       }
     },
     "@remix-run/router": {
@@ -15046,14 +15084,6 @@
         "loose-envify": "^1.1.0"
       }
     },
-    "react-confetti": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.1.0.tgz",
-      "integrity": "sha512-7Ypx4vz0+g8ECVxr88W9zhcQpbeujJAVqL14ZnXJ3I23mOI9/oBVTQ3dkJhUmB0D6XOtCZEM6N0Gm9PMngkORw==",
-      "requires": {
-        "tween-functions": "^1.2.0"
-      }
-    },
     "react-dom": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
@@ -15821,11 +15851,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.1.tgz",
       "integrity": "sha512-v8kOJXpG3WoTN/+at8vK7erSzo6nW6CIaeOvNOkHQVDajfz1ZVeSxCbc6tOH4hrGZW7VUCV0TOXd8CPzYnYkrw=="
-    },
-    "tween-functions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
-      "integrity": "sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA=="
     },
     "type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",
     "@remix-run/dev": "^2.16.8",
+    "@remix-run/fs-routes": "^2.16.8",
+    "@remix-run/route-config": "^2.16.8",
     "@types/bcrypt": "^5.0.0",
     "@types/jsonwebtoken": "^8.5.6",
     "@types/node": "^18.11.18",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
         v3_lazyRouteDiscovery: true,
         v3_singleFetch: true,
         v3_throwAbortReason: true,
+        v3_routeConfig: true,
       },
     }),
   ],


### PR DESCRIPTION
- Add v3_routeConfig flag to vite.config.ts
- Install @remix-run/route-config and @remix-run/fs-routes packages
- Create app/routes.ts with flatRoutes() configuration
- Maintain existing file-based routing structure
- All routes tested and building successfully